### PR TITLE
Fixed spinner error on empty input

### DIFF
--- a/lib/screens/login_signup_page.dart
+++ b/lib/screens/login_signup_page.dart
@@ -59,6 +59,10 @@ class _LoginSignUpPageState extends State<LoginSignUpPage> {
           _errorMessage = e.message;
         });
       }
+    } else {
+      setState(() {
+        _isLoading = false;
+      });
     }
   }
 


### PR DESCRIPTION
Error: Circular spinner would stay on the screen when user presses sign in or create account without any inputs. Made sure to remove spinner if form is not valid.